### PR TITLE
Credential delegation support for the HTTP Handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ and negotiated.
 
 ## HTTP Negotiate
 
-A GSSAPI enabled [http-client] is provided in [v3/http][gssapi-http].
+A GSSAPI enabled [http-client] is provided in [http][gssapi-http].
 
 ## Example code
 
@@ -147,7 +147,7 @@ Examples in Go are available along with C and Java examples collected from the I
 are available [in the gssapi-examples repo](https://github.com/golang-auth/gssapi-examples).
 
 [http-client]: https://pkg.go.dev/net/http#Client
-[gssapi-http]: v3/http
+[gssapi-http]: ./http
 [gssapi-c]: https://github.com/golang-auth/go-gssapi-c
 [go-gssapi-spec]: https://github.com/golang-auth/go-gssapi/wiki/Golang-GSSAPI-bindings-specification
 [rfc7546]: https://datatracker.ietf.org/doc/html/rfc7546

--- a/ctxflags_test.go
+++ b/ctxflags_test.go
@@ -17,11 +17,17 @@ func TestFlagList(t *testing.T) {
 
 func TestFlagName(t *testing.T) {
 	assert.Equal(t, "Delegation", flagName(ContextFlagDeleg))
-	assert.Equal(t, "Integrity", flagName(ContextFlagInteg))
 	assert.Equal(t, "Mutual authentication", flagName(ContextFlagMutual))
-	assert.Equal(t, "Channel Bindings required/present", flagName(ContextFlagChannelBound))
+	assert.Equal(t, "Message replay detection", flagName(ContextFlagReplay))
+	assert.Equal(t, "Out of sequence message detection", flagName(ContextFlagSequence))
+	assert.Equal(t, "Confidentiality", flagName(ContextFlagConf))
+	assert.Equal(t, "Integrity", flagName(ContextFlagInteg))
 	assert.Equal(t, "Anonymous", flagName(ContextFlagAnon))
+	assert.Equal(t, "Channel Bindings required/present", flagName(ContextFlagChannelBound))
+	assert.Equal(t, "DCE style", flagName(ContextFlagDceStyle))
+	assert.Equal(t, "Identify only", flagName(ContextFlagIdentify))
 	assert.Equal(t, "Extended errors", flagName(ContextFlagExtendedError))
+
 }
 
 func TestFlagString(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/golang-auth/go-gssapi/v3
 go 1.24
 
 require (
-	github.com/golang-auth/go-channelbinding v1.0.5
+	github.com/golang-auth/go-channelbinding v1.1.0
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/golang-auth/go-channelbinding v1.0.5 h1:YGeUnRZYYTc6WqyOFnApgtNI7fu2U3WQ4aFlWsVTfe0=
-github.com/golang-auth/go-channelbinding v1.0.5/go.mod h1:YGjl6GMJ3Q+OP8N9sSbV1YHd1++iOIYLuxUzmpQW+pQ=
+github.com/golang-auth/go-channelbinding v1.1.0 h1:4IUbaT8HqBOVkqbzGQ9hd3ZbBKee4hLerhXc9Y+iUwo=
+github.com/golang-auth/go-channelbinding v1.1.0/go.mod h1:YGjl6GMJ3Q+OP8N9sSbV1YHd1++iOIYLuxUzmpQW+pQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/http/common_test.go
+++ b/http/common_test.go
@@ -1,0 +1,167 @@
+package http
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createTestCertificate creates a self-signed certificate for testing
+func createTestCertificate(t *testing.T) *x509.Certificate {
+	// Generate a private key
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	// Create certificate template
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization:  []string{"Test Org"},
+			Country:       []string{"US"},
+			Province:      []string{""},
+			Locality:      []string{"Test City"},
+			StreetAddress: []string{""},
+			PostalCode:    []string{""},
+		},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses: nil,
+	}
+
+	// Create the certificate
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	require.NoError(t, err)
+
+	// Parse the certificate
+	cert, err := x509.ParseCertificate(certDER)
+	require.NoError(t, err)
+
+	return cert
+}
+
+func TestKrbEndpointBinding(t *testing.T) {
+	tests := []struct {
+		name        string
+		tlsState    *tls.ConnectionState
+		serverCert  *x509.Certificate
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "valid server cert provided",
+			tlsState: &tls.ConnectionState{
+				Version:     tls.VersionTLS13,
+				CipherSuite: tls.TLS_AES_128_GCM_SHA256,
+			},
+			serverCert:  createTestCertificate(t),
+			expectError: false,
+		},
+		{
+			name: "valid peer certificate in TLS state",
+			tlsState: &tls.ConnectionState{
+				Version:          tls.VersionTLS13,
+				CipherSuite:      tls.TLS_AES_128_GCM_SHA256,
+				PeerCertificates: []*x509.Certificate{createTestCertificate(t)},
+			},
+			serverCert:  nil,
+			expectError: false,
+		},
+		{
+			name:        "nil TLS state and nil server cert",
+			tlsState:    nil,
+			serverCert:  nil,
+			expectError: true,
+			errorMsg:    "no server certificate found in TLS connection state, needed for channel binding",
+		},
+		{
+			name: "empty peer certificates in TLS state",
+			tlsState: &tls.ConnectionState{
+				Version:          tls.VersionTLS13,
+				CipherSuite:      tls.TLS_AES_128_GCM_SHA256,
+				PeerCertificates: []*x509.Certificate{},
+			},
+			serverCert:  nil,
+			expectError: true,
+			errorMsg:    "no server certificate found in TLS connection state, needed for channel binding",
+		},
+		{
+			name: "TLS state with nil peer certificates",
+			tlsState: &tls.ConnectionState{
+				Version:          tls.VersionTLS13,
+				CipherSuite:      tls.TLS_AES_128_GCM_SHA256,
+				PeerCertificates: nil,
+			},
+			serverCert:  nil,
+			expectError: true,
+			errorMsg:    "no server certificate found in TLS connection state, needed for channel binding",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			binding, err := krbEndpointBinding(tt.tlsState, tt.serverCert)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, binding)
+				if tt.errorMsg != "" {
+					assert.Contains(t, err.Error(), tt.errorMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, binding)
+				assert.NotNil(t, binding.Data)
+				assert.Greater(t, len(binding.Data), 0, "Channel binding data should not be empty")
+			}
+		})
+	}
+}
+
+func TestKrbEndpointBinding_ServerCertPriority(t *testing.T) {
+	// Test that when both serverCert and peer certificates are provided,
+	// the explicitly provided serverCert takes precedence
+	cert1 := createTestCertificate(t)
+	cert2 := createTestCertificate(t)
+
+	tlsState := &tls.ConnectionState{
+		Version:          tls.VersionTLS13,
+		CipherSuite:      tls.TLS_AES_128_GCM_SHA256,
+		PeerCertificates: []*x509.Certificate{cert2},
+	}
+
+	binding1, err1 := krbEndpointBinding(tlsState, cert1)
+	require.NoError(t, err1)
+
+	binding2, err2 := krbEndpointBinding(tlsState, nil)
+	require.NoError(t, err2)
+
+	// The bindings should be different since different certificates were used
+	assert.NotEqual(t, binding1.Data, binding2.Data, "Channel bindings should differ when using different certificates")
+}
+
+func TestKrbEndpointBinding_ConsistentOutput(t *testing.T) {
+	// Test that the same inputs produce the same output
+	cert := createTestCertificate(t)
+	tlsState := &tls.ConnectionState{
+		Version:     tls.VersionTLS13,
+		CipherSuite: tls.TLS_AES_128_GCM_SHA256,
+	}
+
+	binding1, err1 := krbEndpointBinding(tlsState, cert)
+	require.NoError(t, err1)
+
+	binding2, err2 := krbEndpointBinding(tlsState, cert)
+	require.NoError(t, err2)
+
+	assert.Equal(t, binding1.Data, binding2.Data, "Same inputs should produce identical channel bindings")
+}

--- a/http/context.go
+++ b/http/context.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"net"
 	"net/http"
+
+	"github.com/golang-auth/go-gssapi/v3"
 )
 
 type contextKey struct {
@@ -17,6 +19,7 @@ func (k *contextKey) String() string { return "gssapi/http context value " + k.n
 var connContextKey = &contextKey{"conn"}
 var initiatorContextKey = &contextKey{"initiator"}
 var hasCBContextKey = &contextKey{"has-cb"}
+var delegatedCredContextKey = &contextKey{"delegated-cred"}
 
 // Record the net.Conn in the connection's context which is passed to Handlers
 // as part of the http.Request context.
@@ -70,4 +73,19 @@ func getHasCBContext(ctx context.Context) bool {
 	}
 
 	return hasCB
+}
+
+// stashDelegatedCredential stores the delegated credential in the request context
+func stashDelegatedCredential(ctx context.Context, cred gssapi.Credential) context.Context {
+	ctx = context.WithValue(ctx, delegatedCredContextKey, cred)
+	return ctx
+}
+
+// getDelegatedCredentialContext returns the delegated credential from a context
+func getDelegatedCredentialContext(ctx context.Context) gssapi.Credential {
+	cred, ok := ctx.Value(delegatedCredContextKey).(gssapi.Credential)
+	if !ok {
+		return nil
+	}
+	return cred
 }

--- a/http/handler.go
+++ b/http/handler.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"strings"
 
 	"github.com/golang-auth/go-gssapi/v3"
 )
@@ -36,6 +37,11 @@ func setHasChannelBindings(r *http.Request, has bool) *http.Request {
 	return r.WithContext(newCtx)
 }
 
+func setDelegatedCredential(r *http.Request, cred gssapi.Credential) *http.Request {
+	newCtx := stashDelegatedCredential(r.Context(), cred)
+	return r.WithContext(newCtx)
+}
+
 // GetInitiatorName returns the initiator name from the request context if available
 // This can be used by the 'next' http handler called by [Handler.ServeHTTP]
 func GetInitiatorName(r *http.Request) (*InitiatorName, bool) {
@@ -53,13 +59,27 @@ func HasChannelBindings(r *http.Request) bool {
 	return getHasCBContext(r.Context())
 }
 
+// GetDelegatedCredential returns the delegated credential from the request context if available.
+// This can be used by the 'next' http handler called by [Handler.ServeHTTP] to retrieve
+// the credential that was delegated by the initiator during GSSAPI authentication.
+// The credential will only be present if the initiator delegated a credential and the
+// context flag ContextFlagDeleg is set.
+func GetDelegatedCredential(r *http.Request) (gssapi.Credential, bool) {
+	cred := getDelegatedCredentialContext(r.Context())
+	if cred == nil {
+		return nil, false
+	}
+	return cred, true
+}
+
 // Handler is a http.Handler that performs GSSAPI authentication and passes the initiator name to the next handler
 type Handler struct {
-	provider                  gssapi.Provider
-	credential                gssapi.Credential
-	channelBindingDisposition ChannelBindingDisposition
-	channelBindingPresent     bool
-	next                      http.Handler
+	provider                     gssapi.Provider
+	credential                   gssapi.Credential
+	channelBindingDisposition    ChannelBindingDisposition
+	channelBindingPresent        bool
+	delegatedCredentialCachePath string
+	next                         http.Handler
 }
 
 // HandlerOption is a function that can be used to configure the Handler
@@ -89,6 +109,16 @@ func WithAcceptorChannelBindingDisposition(disposition ChannelBindingDisposition
 	}
 }
 
+// WithDelegatedCredentialCache sets the credential cache path template for storing delegated credentials.
+// The cache path may include a %P placeholder which will be replaced with the client principal name.
+// Delegated credentials will be stored using the GSSAPI cred store extensions if the provider supports them.
+// This option requires that the provider supports the HasExtCredStore extension.
+func WithDelegatedCredentialCache(cachePath string) HandlerOption {
+	return func(s *Handler) {
+		s.delegatedCredentialCachePath = cachePath
+	}
+}
+
 // NewHandler creates a new Handler with the given GSSAPI provider and next handler
 func NewHandler(provider gssapi.Provider, next http.Handler, options ...HandlerOption) (*Handler, error) {
 	h := &Handler{
@@ -106,44 +136,71 @@ func NewHandler(provider gssapi.Provider, next http.Handler, options ...HandlerO
 		return nil, errors.New("channel bound GGSSAPI signalling extension unavailable: cannot require channel bindings")
 	}
 
+	// Validate that credential store extension is available if delegated credential cache is configured
+	if h.delegatedCredentialCachePath != "" &&
+		!provider.HasExtension(gssapi.HasExtCredStore) {
+		return nil, errors.New("credential store extension unavailable: cannot store delegated credentials")
+	}
+
 	return h, nil
+}
+
+type negotiateResult struct {
+	outToken      string
+	in            InitiatorName
+	secCtx        gssapi.SecContext
+	delegatedCred gssapi.Credential
 }
 
 // ServeHTTP performs the GSSAPI authentication and passes the initiator name to the next handler
 // It doesn't seem possible to support any more than one GSSAPI round trip per request with
 // the Go [http.Server] implementation without hijacking the connection.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var secCtx gssapi.SecContext
 	authzType, authzToken := parseAuthzHeader(&r.Header)
 	if authzType == "negotiate" && len(authzToken) > 0 {
-		outToken, in, err := h.negotiateOnce(authzToken, r)
+		result, err := h.negotiateOnce(authzToken, r)
 		if err != nil {
 			h.log(r.Context(), "Error negotiating GSSAPI context: %s", err)
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}
-		if outToken != "" {
-			w.Header().Set("WWW-Authenticate", "Negotiate "+outToken)
+		secCtx = result.secCtx
+
+		if result.outToken != "" {
+			w.Header().Set("WWW-Authenticate", "Negotiate "+result.outToken)
 		}
-		r = setInitiatorName(r, in)
+		r = setInitiatorName(r, &result.in)
 		r = setHasChannelBindings(r, h.channelBindingPresent)
+		if result.delegatedCred != nil {
+			r = setDelegatedCredential(r, result.delegatedCred)
+		}
 	} else {
 		w.Header().Set("WWW-Authenticate", "Negotiate")
 		w.WriteHeader(http.StatusUnauthorized)
 		return
 	}
 
+	// the secctx needs to survive until the "real" handler is done so that
+	// the delegated credential isn't destroyed if the handler needs it.
+	defer func() {
+		if secCtx != nil {
+			secCtx.Delete() //nolint:errcheck
+		}
+	}()
+
 	h.next.ServeHTTP(w, r)
 }
 
 // negotiateOnce performs a single GSSAPI round trip to establish the context
-// and returns the output token and initiator name.
-func (h *Handler) negotiateOnce(negotiateToken string, r *http.Request) (string, *InitiatorName, error) {
+// and returns the output token, initiator name, and delegated credential.
+func (h *Handler) negotiateOnce(negotiateToken string, r *http.Request) (*negotiateResult, error) {
 	outToken := ""
 	in := InitiatorName{}
 
 	rawToken, err := base64.StdEncoding.DecodeString(negotiateToken)
 	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
 
 	opts := []gssapi.AcceptSecContextOption{}
@@ -157,12 +214,12 @@ func (h *Handler) negotiateOnce(negotiateToken string, r *http.Request) (string,
 		if tlsConn, ok := conn.(*tls.Conn); ok {
 			serverCert, err := h.getServerCertificate(r.Context())
 			if err != nil {
-				return "", nil, fmt.Errorf("get server certificate: %w", err)
+				return nil, fmt.Errorf("get server certificate: %w", err)
 			}
 			tlsState := tlsConn.ConnectionState()
 			binding, err := krbEndpointBinding(&tlsState, serverCert)
 			if err != nil {
-				return "", nil, fmt.Errorf("acceptor channel binding: %w", err)
+				return nil, fmt.Errorf("acceptor channel binding: %w", err)
 			}
 			opts = append(opts, gssapi.WithAcceptorChannelBinding(binding))
 		}
@@ -170,12 +227,11 @@ func (h *Handler) negotiateOnce(negotiateToken string, r *http.Request) (string,
 
 	secCtx, err := h.provider.AcceptSecContext(opts...)
 	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
-	defer secCtx.Delete() //nolint:errcheck
 	respToken, info, err := secCtx.Continue(rawToken)
 	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
 	if len(respToken) > 0 {
 		outToken = base64.StdEncoding.EncodeToString(respToken)
@@ -185,7 +241,7 @@ func (h *Handler) negotiateOnce(negotiateToken string, r *http.Request) (string,
 
 	// Verify that channel binding requirements are ment
 	if h.channelBindingDisposition == ChannelBindingDispositionRequire && !h.channelBindingPresent {
-		return "", nil, fmt.Errorf("%w (required but not supplied by initiator)", gssapi.ErrBadBindings)
+		return nil, fmt.Errorf("%w (required but not supplied by initiator)", gssapi.ErrBadBindings)
 	}
 
 	if info.InitiatorName != nil {
@@ -200,7 +256,27 @@ func (h *Handler) negotiateOnce(negotiateToken string, r *http.Request) (string,
 		}
 	}
 
-	return outToken, &in, nil
+	// Extract delegated credential if present
+	var delegatedCred gssapi.Credential
+
+	if info.DelegatedCredential != nil {
+		delegatedCred = info.DelegatedCredential
+
+		// Store delegated credential if cache path is configured
+		if h.delegatedCredentialCachePath != "" && in.PrincipalName != "" && info.Mech != nil {
+			if err := h.storeDelegatedCredential(delegatedCred, in.PrincipalName, info.Mech); err != nil {
+				h.log(r.Context(), "Error storing delegated credential: %s", err)
+				// Continue processing even if storage fails
+			}
+		}
+	}
+
+	return &negotiateResult{
+		outToken:      outToken,
+		in:            in,
+		secCtx:        secCtx,
+		delegatedCred: delegatedCred,
+	}, nil
 }
 
 func (h *Handler) log(ctx context.Context, format string, args ...interface{}) {
@@ -330,4 +406,27 @@ func (h *Handler) getServerCertificate(ctx context.Context) (*x509.Certificate, 
 	}
 
 	return cert.Leaf, nil
+}
+
+// storeDelegatedCredential stores a delegated credential using the GSSAPI cred store extensions.
+// The cache path template is processed to replace %P with the principal name.
+func (h *Handler) storeDelegatedCredential(cred gssapi.Credential, principalName string, mech gssapi.GssMech) error {
+	// Check if credential supports the cred store extension
+	credExt, ok := cred.(gssapi.CredentialExtCredStore)
+	if !ok {
+		return errors.New("credential does not support credential store extension")
+	}
+
+	// Replace %P placeholder with principal name
+	cachePath := strings.ReplaceAll(h.delegatedCredentialCachePath, "%P", principalName)
+
+	// Store the credential
+	_, _, err := credExt.StoreInto(
+		mech,
+		gssapi.CredUsageInitiateOnly,
+		true, // overwrite
+		true, // defaultCred
+		gssapi.WithCredStoreCCache(cachePath),
+	)
+	return err
 }

--- a/http/test/go.mod
+++ b/http/test/go.mod
@@ -12,7 +12,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/golang-auth/go-channelbinding v1.0.5 // indirect
+	github.com/golang-auth/go-channelbinding v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/http/test/go.sum
+++ b/http/test/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/golang-auth/go-channelbinding v1.0.5 h1:YGeUnRZYYTc6WqyOFnApgtNI7fu2U3WQ4aFlWsVTfe0=
-github.com/golang-auth/go-channelbinding v1.0.5/go.mod h1:YGjl6GMJ3Q+OP8N9sSbV1YHd1++iOIYLuxUzmpQW+pQ=
+github.com/golang-auth/go-channelbinding v1.1.0 h1:4IUbaT8HqBOVkqbzGQ9hd3ZbBKee4hLerhXc9Y+iUwo=
+github.com/golang-auth/go-channelbinding v1.1.0/go.mod h1:YGjl6GMJ3Q+OP8N9sSbV1YHd1++iOIYLuxUzmpQW+pQ=
 github.com/golang-auth/go-gssapi-c v0.1.0 h1:ULQOdbh2dZwDpdqt1CHkdvyKL25bRuJ/uipUVymBXao=
 github.com/golang-auth/go-gssapi-c v0.1.0/go.mod h1:2FFJ0C7m4aKGMY5jP1UKR8C4T0OEMUmLdOa1+mTjKcs=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Support for the delegation of a credential from the client.  The handler stores the delegated credential in the request context for consumption by child handlers.

Also support for the credential store extension, to put the received delegated credential into a credential cache other than the default memory cache.

Improve test coverage